### PR TITLE
ci: upgrade GitHub Actions dependencies and improve Python setup

### DIFF
--- a/.github/workflows/Deploy GitHub Pages.yml
+++ b/.github/workflows/Deploy GitHub Pages.yml
@@ -42,12 +42,12 @@ jobs:
 
       - name: Build VitePress docs
         run: yarn docs:md && yarn docs:build
-        
+
       - name: Create assets directory
         run: mkdir -p ./docs/.vitepress/dist/assets
-        
+
       - name: Download coverage badge
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: coverage-badge
           path: ./docs/.vitepress/dist/assets

--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -34,17 +34,36 @@ jobs:
         with:
           python-version: '3.13'
 
-      - name: Install Python dependencies
+      - name: Cache uv global directory
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/uv # Default uv cache path on Linux
+          key: ${{ runner.os }}-uv-${{ hashFiles('**/requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-uv-
+
+      - name: Install uv and Python dependencies
+        shell: bash
         run: |
-          python -m venv .venv # Create a new virtual environment
-          source .venv/bin/activate # Activate the virtual environment
-          python -m pip install --upgrade pip # Update pip
-          pip install -r requirements.txt # Install packages using a requirements file
+          # Install uv
+          curl -LsSf https://astral.sh/uv/install.sh | sh
+          # The installer script should add uv to PATH. If not, source the cargo env or add manually.
+          # Example if installed via cargo (common for Rust tools):
+          source "$HOME/.cargo/env"
+
+          # Create virtual environment using uv, explicitly using the Python from setup-python
+          uv venv .venv --python $(which python)
+
+          # Activate virtual environment for this script block
+          source .venv/bin/activate
+
+          # Install packages using uv
+          uv pip install -r requirements.txt --keyring-provider=disabled
 
       - name: Run tests
         run: yarn test
 
-      - name: Upload coverage badge
+      - name: Upload coverage badge artifact
         uses: actions/upload-artifact@v4 # Updated to v4
         with:
           name: coverage-badge


### PR DESCRIPTION
- Update actions/download-artifact from v3 to v4 in Deploy GitHub Pages workflow
- Replace traditional Python venv setup with uv in Tests workflow for faster dependency installation
- Add caching for uv global directory to speed up subsequent runs
- Standardize artifact upload action version to v4 across workflows