### PR TITLE
Update CI workflows to use Node.js 24

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
 
       - name: Enable Corepack
         run: corepack enable

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,8 +22,11 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
           registry-url: 'https://registry.npmjs.org/'
+
+      - name: Update npm to latest
+        run: npm install -g npm@latest # Ensures npm >=10.8.3 or higher for 2025 changes
 
       - name: Enable Corepack
         run: corepack enable
@@ -68,6 +71,9 @@ jobs:
           fi
         # Set to continue if package has never been published before (npm view might error)
         continue-on-error: true
+
+      - name: Debug npm config
+        run: npm config list
 
       - name: Publish to npm
         # Only run if version does not exist

--- a/.github/workflows/test-react-example.yml
+++ b/.github/workflows/test-react-example.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '22' # Use Node.js 22.x
+          node-version: '24'
           cache: 'yarn' # Cache Yarn dependencies globally
 
       - name: Install Yarn

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
 
       - name: Enable Corepack
         run: corepack enable

--- a/coverage/coverage-badge.svg
+++ b/coverage/coverage-badge.svg
@@ -1,14 +1,14 @@
 <svg width="103.3" height="20" viewBox="0 0 1033 200" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="coverage: 100%">
   <title>coverage: 100%</title>
-  <linearGradient id="GwCmh" x2="0" y2="100%">
+  <linearGradient id="IzRfW" x2="0" y2="100%">
     <stop offset="0" stop-opacity=".1" stop-color="#EEE"/>
     <stop offset="1" stop-opacity=".1"/>
   </linearGradient>
-  <mask id="gKHtD"><rect width="1033" height="200" rx="30" fill="#FFF"/></mask>
-  <g mask="url(#gKHtD)">
+  <mask id="aIRaf"><rect width="1033" height="200" rx="30" fill="#FFF"/></mask>
+  <g mask="url(#aIRaf)">
     <rect width="603" height="200" fill="#555"/>
     <rect width="430" height="200" fill="#49c31a" x="603"/>
-    <rect width="1033" height="200" fill="url(#GwCmh)"/>
+    <rect width="1033" height="200" fill="url(#IzRfW)"/>
   </g>
   <g aria-hidden="true" fill="#fff" text-anchor="start" font-family="Verdana,DejaVu Sans,sans-serif" font-size="110">
     <text x="60" y="148" textLength="503" fill="#000" opacity="0.25">coverage</text>


### PR DESCRIPTION
Bump Node.js version from 22 to 24 in deploy, publish, and test workflows. The publish workflow also updates npm to the latest version and adds a debug step for npm config to ensure compatibility with upcoming 2025 changes.