### PR TITLE
Parse workflows list in publish workflow

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -2,9 +2,8 @@ name: Publish to npm
 
 on:
   # ⚠️ SINGLE SOURCE OF TRUTH ⚠️
-  # When adding/removing test workflows, update BOTH locations:
-  # 1. This workflows list
-  # 2. The requiredWorkflows array in verify-all-versions job (L52-62)
+  # The 'verify-all-versions' job reads this list dynamically from this file.
+  # Only update this list when adding/removing test workflows.
   workflow_run:
     workflows:
       [
@@ -47,19 +46,30 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            // ⚠️ IMPORTANT: Keep this list in sync with workflow_run.workflows (L9-L20)
-            // This duplication is required due to GitHub Actions platform limitations
-            const requiredWorkflows = [
-              'Linux 20',
-              'Linux 22',
-              'Linux 24',
-              'Win 20',
-              'Win 22',
-              'Win 24',
-              'macOS 20',
-              'macOS 22',
-              'macOS 24'
-            ];
+            // ⚠️ Parse the required workflows from the file itself to avoid duplication
+            // We read the current file content, finding the 'workflows' array in the 'on' trigger
+            const { data: fileData } = await github.rest.repos.getContent({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              path: '.github/workflows/publish-npm.yml',
+              ref: context.sha
+            });
+
+            const content = Buffer.from(fileData.content, 'base64').toString('utf8');
+            const match = content.match(/workflows:\s*\[([\s\S]*?)\]/);
+
+            if (!match) {
+              core.setFailed('Could not parse workflows list from publish-npm.yml. Ensure "workflows: [...]" format is preserved.');
+              return;
+            }
+
+            const requiredWorkflows = match[1]
+              .split(',')
+              .map(s => s.trim())
+              .filter(s => s.length > 0)
+              .map(s => s.replace(/^['"]|['"]$/g, '')); // Remove quotes
+
+            console.log('Required workflows (parsed from YAML):', requiredWorkflows);
 
             // Get the workflow run that triggered this publish
             const triggeringRun = context.payload.workflow_run;


### PR DESCRIPTION
Replace the duplicated hardcoded requiredWorkflows array with logic that reads this file from the repo and parses the 'workflows: [...]' list at runtime. This ensures a single source of truth for the workflows list, avoiding manual sync errors. The script fetches publish-npm.yml via the GitHub API, extracts and normalizes the entries, logs them, and fails with a clear message if parsing fails.